### PR TITLE
feat: start httpServer on environment

### DIFF
--- a/adonis-environment.js
+++ b/adonis-environment.js
@@ -7,7 +7,7 @@ const NodeEnvironment = require('jest-environment-node');
 
 const iocSymbol = Symbol.for('ioc.use');
 
-let app;
+let server;
 let providersWithReadyHook;
 let providersWithShutdownHook;
 
@@ -28,16 +28,13 @@ class AdonisEnvironment extends NodeEnvironment {
     register(this.rootDir, options);
   }
 
-  async createApplication() {
-    if (!app) {
+  async createServer() {
+    if (!server) {
       const ignitor = new Ignitor(this.rootDir);
-      app = ignitor.application('test');
-      await app.setup();
-      await app.registerProviders();
-      await app.bootProviders();
-      await app.requirePreloads();
-      providersWithReadyHook = app.providersWithReadyHook;
-      providersWithShutdownHook = app.providersWithShutdownHook;
+      server = ignitor.httpServer();
+      server.application.switchEnvironment('test');      
+      providersWithReadyHook = server.application.providersWithReadyHook;
+      providersWithShutdownHook = server.application.providersWithShutdownHook;
     }
   }
 
@@ -48,10 +45,10 @@ class AdonisEnvironment extends NodeEnvironment {
       process.env.NODE_ENV = 'testing';
     }
     try {
-      await this.createApplication();
-      app.providersWithReadyHook = providersWithReadyHook;
-      app.providersWithShutdownHook = providersWithShutdownHook;
-      await app.start();
+      await this.createServer();
+      server.application.providersWithReadyHook = providersWithReadyHook;
+      server.application.providersWithShutdownHook = providersWithShutdownHook;
+      await server.start();
       this.global[iocSymbol] = global[iocSymbol];
     } catch (e) {
       console.error('Error while setting up Adonis test environment');
@@ -61,9 +58,9 @@ class AdonisEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
-    await app.shutdown();
-    app.isShuttingDown = false;
-    app.state = 'booted';
+    await server.close();
+    server.application.isShuttingDown = false;
+    server.application.state = 'booted';
     await super.teardown();
   }
 }

--- a/adonis-environment.js
+++ b/adonis-environment.js
@@ -32,7 +32,7 @@ class AdonisEnvironment extends NodeEnvironment {
     if (!server) {
       const ignitor = new Ignitor(this.rootDir);
       server = ignitor.httpServer();
-      server.application.switchEnvironment('test');      
+      server.application.switchEnvironment('test');
       providersWithReadyHook = server.application.providersWithReadyHook;
       providersWithShutdownHook = server.application.providersWithShutdownHook;
     }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/zakodium/adonis-jest#readme",
   "dependencies": {
     "@adonisjs/ioc-transformer": "^2.2.1",
-    "@adonisjs/require-ts": "^2.0.4",
+    "@adonisjs/require-ts": "^2.0.11",
     "jest-environment-node": "^27.0.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/zakodium/adonis-jest#readme",
   "dependencies": {
-    "@adonisjs/ioc-transformer": "^2.2.1",
+    "@adonisjs/ioc-transformer": "^2.3.3",
     "@adonisjs/require-ts": "^2.0.11",
     "jest-environment-node": "^27.0.3"
   },


### PR DESCRIPTION
I've modified the `adonis-environment` to ignite the whole `HttpServer`, instead of the `Application` alone.

It still leaks some server logs into the jest output, and I think it would be better if I were able to run the server only on a few test files - the ones testing HTTP routes - while generally using only the `Application`.

Also, it requires `--runInBand` for some reason I haven't found yet. I've tried setting up a different port at each instantiated server and it still didn't work.

Anyway, it's a start.